### PR TITLE
Remove extra returns from the prompt function

### DIFF
--- a/oh-my-posh.psm1
+++ b/oh-my-posh.psm1
@@ -35,12 +35,10 @@ function Set-Prompt {
         if(Test-IsVanillaWindow) {
             Write-Host -Object ($pwd.ProviderPath) -NoNewline
             Write-VcsStatus
-            return '> '
         }
 
         Reset-CursorPosition
         Write-Theme -lastCommandFailed $lastCommandFailed
-        return ' '
     }
 
     Set-Item -Path Function:prompt -Value $Prompt -Force


### PR DESCRIPTION
I've done a little investigation into # 116 and I've discovered the problem that causes the prompt to not be redisplayed properly by PSReadline.

PSReadline will invoke the prompt function when it needs to redisplay the prompt; however, it has a check that checks that the prompt function doesn't return more than one prompt string (see https://github.com/lzybkr/PSReadLine/blob/3d246d9/PSReadLine/ReadLine.cs#L1035). If it finds more than one prompt string, it bugs out and displays a default prompt (the `PS>` we see appear instead of our prompt, see https://github.com/lzybkr/PSReadLine/blob/3d246d9/PSReadLine/ReadLine.cs#L1058).

If we run our prompt function and inspect its return, we can see that it returns more than one string:

```powershell
> (& (Get-Item Function:Prompt)).Length
2
```

Turns out that this is because both `Write-VcsStatus` and `Write-Theme` already return the prompt string, so the extra `return '> '` and `return ' '` is returning an extra unnecessary string from our function, making it return two strings instead of just the one prompt string we need.

Removing these invalid extra returns solves the problem.

I've tested this in the following configurations and it works okay:
1. * Windows PowerShell 5.1 (Windows 10 1809)
    * PSReadline 2.0.0-beta2
    * posh-git 0.7.3
2. * PowerShell Core 6.1.1
    * PSReadline 2.0.0-beta3
    * posh-git 1.0.0-beta2